### PR TITLE
Highlight misspelled words in red for better visibility

### DIFF
--- a/huncolor.c
+++ b/huncolor.c
@@ -10,8 +10,8 @@
 const char *aff_path = "/usr/share/hunspell/en_US.aff";
 const char *dic_path = "/usr/share/hunspell/en_US.dic";
 
-#define START "\033[1m"
-#define STOP "\033[22m"
+#define START "\033[31m"
+#define STOP "\033[0m"
 
 #define SMALLBUF 80
 


### PR DESCRIPTION
This PR modifies the color scheme of HunspellColorize to make
misspelled words appear in red in the terminal. Previously, the
program used ANSI bold sequences (\033[1m / \033[22m) which some
terminals do not display clearly.

Changes made:
- Updated START and STOP macros:
  #define START "\033[31m"
  #define STOP  "\033[0m"

This improves visibility of misspelled words and provides a clearer
visual cue for users reading text through the program.

The Hunspell functionality remains unchanged, and the program still
correctly identifies misspelled words using the same dictionaries.

Tested on WSL/Ubuntu with English dictionary (en_US.aff/en_US.dic).

No additional dependencies are required.


Suggested Usage:
echo "This is a simpel txt" | ./huncolor | less -R

Now, misspelled words like "simpel" and "txt" appear in red.
